### PR TITLE
Added Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3']
-        laravel: ['9.2', '9.52', '10.0', '10.48', '11.0']
+        laravel: ['9.2', '9.52', '10.0', '10.48', '11.0', '12.0']
         exclude:
           - php: '8.0'
             laravel: '10.0'
@@ -17,8 +17,12 @@ jobs:
             laravel: '10.48'
           - php: '8.0'
             laravel: '11.0'
+          - php: '8.0'
+            laravel: '12.0'
           - php: '8.1'
             laravel: '11.0'
+          - php: '8.1'
+            laravel: '12.0'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # OpsGenie Notifications for Laravel
 
+## Unreleased
+##### 2025-XX-YY
+
+- Added Laravel 12 support
+
 ## 1.3.0
 ##### 2024-03-15
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/389939873/shield?branch=master)](https://styleci.io/repos/389939873)
 [![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 
-This package enables Laravel 9 - 11 Applications to send notification to OpsGenie.
+This package enables Laravel 9 - 12 Applications to send notification to OpsGenie.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/notifications": "^9.2|^10.0|^11.0",
-        "illuminate/support": "^9.2|^10.0|^11.0",
-        "illuminate/http": "^9.2|^10.0|^11.0",
+        "illuminate/notifications": "^9.2|^10.0|^11.0|^12.0",
+        "illuminate/support": "^9.2|^10.0|^11.0|^12.0",
+        "illuminate/http": "^9.2|^10.0|^11.0|^12.0",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0|^10.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0"
+        "phpunit/phpunit": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": { "Konekt\\OpsGenie\\": "src/" }


### PR DESCRIPTION
Added support for Laravel 12, based this on the work done in https://github.com/artkonekt/opsgenie-laravel/commit/a83ed27ee0a005ed60ad6a5cb85bbba75156eeca, there doens't appear to be any breaking changes in the Framework so all tests are passing locally as-is.
