### PR TITLE
Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,32 +9,22 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3', '8.4']
-        laravel: ['9.2', '9.52', '10.0', '10.48', '11.0', '11.44', '12.0', '12.1', '13.0']
+        laravel: ['9', '10', '11', '12', '13']
         exclude:
           - php: '8.0'
-            laravel: '10.0'
+            laravel: '10'
           - php: '8.0'
-            laravel: '10.48'
+            laravel: '11'
           - php: '8.0'
-            laravel: '11.0'
+            laravel: '12'
           - php: '8.0'
-            laravel: '11.44'
-          - php: '8.0'
-            laravel: '12.0'
-          - php: '8.0'
-            laravel: '12.1'
-          - php: '8.0'
-            laravel: '13.0'
+            laravel: '13'
           - php: '8.1'
-            laravel: '11.0'
+            laravel: '11'
           - php: '8.1'
-            laravel: '11.44'
+            laravel: '12'
           - php: '8.1'
-            laravel: '12.0'
-          - php: '8.1'
-            laravel: '12.1'
-          - php: '8.1'
-            laravel: '13.0'
+            laravel: '13'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         laravel: ['10', '11', '12', '13']
         exclude:
           - php: '8.1'
@@ -16,6 +16,8 @@ jobs:
           - php: '8.1'
             laravel: '12'
           - php: '8.1'
+            laravel: '13'
+          - php: '8.2'
             laravel: '13'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3', '8.4']
-        laravel: ['9.2', '9.52', '10.0', '10.48', '11.0', '11.44', '12.0', '12.1']
+        laravel: ['9.2', '9.52', '10.0', '10.48', '11.0', '11.44', '12.0', '12.1', '13.0']
         exclude:
           - php: '8.0'
             laravel: '10.0'
@@ -23,6 +23,8 @@ jobs:
             laravel: '12.0'
           - php: '8.0'
             laravel: '12.1'
+          - php: '8.0'
+            laravel: '13.0'
           - php: '8.1'
             laravel: '11.0'
           - php: '8.1'
@@ -31,6 +33,8 @@ jobs:
             laravel: '12.0'
           - php: '8.1'
             laravel: '12.1'
+          - php: '8.1'
+            laravel: '13.0'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,24 +8,14 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
-        laravel: ['9', '10', '11', '12', '13']
+        php: ['8.1', '8.2', '8.3', '8.4']
+        laravel: ['10', '11', '12', '13']
         exclude:
-          - php: '8.0'
-            laravel: '10'
-          - php: '8.0'
-            laravel: '11'
-          - php: '8.0'
-            laravel: '12'
-          - php: '8.0'
-            laravel: '13'
           - php: '8.1'
             laravel: '11'
           - php: '8.1'
             laravel: '12'
           - php: '8.1'
-            laravel: '13'
-          - php: '8.2'
             laravel: '13'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
             laravel: '12'
           - php: '8.1'
             laravel: '13'
+          - php: '8.2'
+            laravel: '13'
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout
@@ -37,16 +39,6 @@ jobs:
           tools: composer:v2
       - name: Lock Laravel Version
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-update -v
-      - name: Testbench Version Adjustments
-        run: |
-          is_smaller_version() [[ $(echo -e "$1\n$2"|sort -V|head -1) != $2 ]]
-          is_smaller_version "${{ matrix.laravel }}" "9.36" && composer req "orchestra/testbench-core:7.10.2" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.34" && composer req "orchestra/testbench-core:7.8.1" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.32" && composer req "orchestra/testbench-core:7.7.1" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.12" && composer req "orchestra/testbench-core:7.4.0" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.7" && composer req "orchestra/testbench-core:7.3.0" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.6" && composer req "orchestra/testbench-core:7.2.0" --no-update
-          is_smaller_version "${{ matrix.laravel }}" "9.5" && composer req "orchestra/testbench-core:7.1.0" --no-update || true
       - name: Composer Install
         run: composer install --prefer-dist --no-progress --no-interaction
       - name: Run Tests

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 ##### 2026-XX-YY
 
 - Added Laravel 13 support
+- Removed Laravel 9 support
+- Removed PHP 8.0 support
 
 ## 1.4.0
 ##### 2025-03-11

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # OpsGenie Notifications for Laravel
 
+## Unreleased
+##### 2026-XX-YY
+
+- Added Laravel 13 support
+
 ## 1.4.0
 ##### 2025-03-11
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/389939873/shield?branch=master)](https://styleci.io/repos/389939873)
 [![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 
-This package enables Laravel 9 - 12 Applications to send notification to OpsGenie.
+This package enables Laravel 9 - 13 Applications to send notification to OpsGenie.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/389939873/shield?branch=master)](https://styleci.io/repos/389939873)
 [![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 
-This package enables Laravel 9 - 13 Applications to send notification to OpsGenie.
+This package enables Laravel 10 - 13 Applications to send notification to OpsGenie.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/notifications": "^9.2|^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "^9.2|^10.0|^11.0|^12.0|^13.0",
-        "illuminate/http": "^9.2|^10.0|^11.0|^12.0|^13.0",
+        "php": "^8.1",
+        "illuminate/notifications": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0"
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": { "Konekt\\OpsGenie\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/notifications": "^9.2|^10.0|^11.0|^12.0",
-        "illuminate/support": "^9.2|^10.0|^11.0|^12.0",
-        "illuminate/http": "^9.2|^10.0|^11.0|^12.0",
+        "illuminate/notifications": "^9.2|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^9.2|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^9.2|^10.0|^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0|^10.0|^11.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0"
+        "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": { "Konekt\\OpsGenie\\": "src/" }

--- a/tests/AbcSmokeTest.php
+++ b/tests/AbcSmokeTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Konekt\OpsGenie\Tests;
 
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 class AbcSmokeTest extends PHPUnitTestCase
@@ -22,9 +24,8 @@ class AbcSmokeTest extends PHPUnitTestCase
 
     /**
      * Very Basic smoke test case for testing against parse errors, etc
-     *
-     * @test
      */
+    #[Test]
     public function smoke()
     {
         $this->assertTrue(true);
@@ -32,10 +33,9 @@ class AbcSmokeTest extends PHPUnitTestCase
 
     /**
      * Test for minimum PHP version
-     *
-     * @depends smoke
-     * @test
      */
+    #[Test]
+    #[Depends('smoke')]
     public function php_version_satisfies_requirements()
     {
         $this->assertFalse(

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -19,10 +19,11 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Konekt\OpsGenie\Tests\Examples\OpsGenieTestNotification;
+use PHPUnit\Framework\Attributes\Test;
 
 class ChannelTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_sends_a_notification()
     {
         $responseBody = [

--- a/tests/Commands/CreateAlertTest.php
+++ b/tests/Commands/CreateAlertTest.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
 use Konekt\OpsGenie\Client\OpsGenieClient;
 use Konekt\OpsGenie\Commands\CreateAlert;
 use Konekt\OpsGenie\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class CreateAlertTest extends TestCase
 {
@@ -40,7 +41,7 @@ class CreateAlertTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_executed()
     {
         $this->genie->execute(CreateAlert::withMessage('Alert message'));

--- a/tests/Commands/PingHeartbeatTest.php
+++ b/tests/Commands/PingHeartbeatTest.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
 use Konekt\OpsGenie\Client\OpsGenieClient;
 use Konekt\OpsGenie\Commands\PingHeartbeat;
 use Konekt\OpsGenie\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class PingHeartbeatTest extends TestCase
 {
@@ -40,7 +41,7 @@ class PingHeartbeatTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_executed()
     {
         $this->genie->execute(new PingHeartbeat('heartbeat-name'));

--- a/tests/Models/AlertTest.php
+++ b/tests/Models/AlertTest.php
@@ -16,11 +16,12 @@ namespace Konekt\OpsGenie\Tests\Models;
 
 use Konekt\OpsGenie\Models\Alert;
 use Konekt\OpsGenie\Models\Priority;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 class AlertTest extends PHPUnitTestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated_with_a_message_only()
     {
         $alert = new Alert('We have a problem');
@@ -28,7 +29,7 @@ class AlertTest extends PHPUnitTestCase
         $this->assertEquals('We have a problem', $alert->message);
     }
 
-    /** @test */
+    #[Test]
     public function it_has_a_default_priority_if_unspecified()
     {
         $alert = new Alert('');
@@ -37,7 +38,7 @@ class AlertTest extends PHPUnitTestCase
         $this->assertEquals(Priority::__DEFAULT, $alert->priority->value());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_convert_to_an_array()
     {
         $alert = new Alert('Boo Botsie');
@@ -48,7 +49,7 @@ class AlertTest extends PHPUnitTestCase
         $this->assertEquals(Priority::__DEFAULT, $array['priority']);
     }
 
-    /** @test */
+    #[Test]
     public function attributes_can_be_set_in_the_constructor()
     {
         $alert = new Alert('PJ Masks', [
@@ -66,7 +67,7 @@ class AlertTest extends PHPUnitTestCase
         $this->assertEquals('Contact Mr. Fritz Teufel', $alert->note);
     }
 
-    /** @test */
+    #[Test]
     public function priority_can_be_set_in_the_constructor()
     {
         $alert1 = new Alert('', ['priority' => 'P1']);

--- a/tests/Models/PriorityTest.php
+++ b/tests/Models/PriorityTest.php
@@ -15,11 +15,12 @@ declare(strict_types=1);
 namespace Konekt\OpsGenie\Models\Tests;
 
 use Konekt\OpsGenie\Models\Priority;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 class PriorityTest extends PHPUnitTestCase
 {
-    /** @test */
+    #[Test]
     public function it_accepts_any_valid_value()
     {
         $p1 = new Priority('P1');
@@ -44,21 +45,21 @@ class PriorityTest extends PHPUnitTestCase
         $this->assertEquals('P5', $p5->value());
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_a_default_if_no_value_was_specified()
     {
         $priority = new Priority();
         $this->assertEquals(Priority::__DEFAULT, $priority->value());
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_an_exception_on_an_invalid_value()
     {
         $this->expectException(\LogicException::class);
         new Priority('asd');
     }
 
-    /** @test */
+    #[Test]
     public function magic_constructors_work()
     {
         $p1 = Priority::P1();
@@ -83,7 +84,7 @@ class PriorityTest extends PHPUnitTestCase
         $this->assertEquals('P5', $p5->value());
     }
 
-    /** @test */
+    #[Test]
     public function can_be_casted_to_string()
     {
         $p4 = Priority::P4();

--- a/tests/OpsGenieClientTest.php
+++ b/tests/OpsGenieClientTest.php
@@ -18,10 +18,11 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Konekt\OpsGenie\Client\OpsGenieClient;
+use PHPUnit\Framework\Attributes\Test;
 
 class OpsGenieClientTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_sends_a_proper_create_alert_request()
     {
         $responseBody = [
@@ -47,7 +48,7 @@ class OpsGenieClientTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function the_endpoint_can_be_changed()
     {
         $responseBody = [


### PR DESCRIPTION
Added support for installing with Laravel 13, running the CI caused a bunch of failures due to composer refusing to install vulnerable versions of Laravel. To remedy this I've dropped support for 9, there was no patched version. And allowed any minor version to be installed for the remaining major versions. It should still be possible to add specific minor versions to the matrix if desired. 

Let me know what you think. Cheers.